### PR TITLE
Bug fixes in event listeners

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -308,7 +308,7 @@ var User = Backbone.Model.extend({
                     nags.visits = 0;
                     nags.lastNag = now;
                 } else {
-                    site.vists++;
+                    site.visits++;
                     nags.visits++;
                 }
             } else {

--- a/js/main.js
+++ b/js/main.js
@@ -397,10 +397,13 @@ function openItem(tabId, url, favIconUrl, title, event_type) {
 
         // close previous activeItem
         if (activeItem !== undefined) {
-            if (activeItem.url !== url && activeItem.tabId !== tabId) {
+            if (activeItem.url !== url || activeItem.tabId !== tabId) {
                 closeItem(activeItem.tabId, activeItem.url, "blur", timeCheck.time);
                 activeItem = undefined;
                 updateBadge("");
+            } else if (activeItem.url === url) {
+                // page was refreshed
+                return;
             }
         }
         if (!user.inWhitelist(url) && !user.inBlackList(url) && user.shouldNag(url)) {

--- a/js/main.js
+++ b/js/main.js
@@ -272,7 +272,7 @@ var User = Backbone.Model.extend({
         if (url !== "") {
             var nags = this.getNags();
             if (url in nags) {
-                nags[url] = Math.max(Math.min(nags[url].factor * rate, 16), 1);
+                nags[url].factor = Math.max(Math.min(nags[url].factor * rate, 16), 1);
             } else {
                 nags[url] = this.createNagSite();
             }


### PR DESCRIPTION
- [9831c82] Console error: nag dictionary objects were getting assigned to numbers (e.g. key: facebook.com, value: 2), triggered error when trying to update field of object
- [9b659a3] If while on active page, user navigates to another page then goes back, it starts a new active session and overrides old tracked time
- [9b659a3] Doesn’t detect refresh as end of page, starts new session though when page reloads and overrides old session
- [ae7c596] Typo in incrementing visits to a site object